### PR TITLE
Fix pinging to MiNET Servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ UNCONNECTED_PING.prototype.encode = function () {
   this.bb
     .writeLong(this.pingId)
     .append(RAKNET.MAGIC, "hex")
+    .writeLong(0)
     .flip()
     .compact();
 };


### PR DESCRIPTION
MiNET is strict about the packets, the UNCONNECTED_PING was missing the server ID.
